### PR TITLE
Fix resurgent Rust compilation errors and warnings

### DIFF
--- a/identity/src/aes_ctr.rs
+++ b/identity/src/aes_ctr.rs
@@ -2,7 +2,7 @@
 //! primarily for deriving P1 and P2 matrix components in MAYO.
 
 use aes::Aes128;
-use aes::cipher::{KeyInit, generic_array::GenericArray, StreamCipher, KeyIvInit};
+use aes::cipher::{generic_array::GenericArray, StreamCipher, KeyIvInit}; // Removed KeyInit
 use ctr::Ctr128BE; // Using Big Endian as is common in cryptographic contexts.
 use crate::types::SeedPK;
 use crate::params::MayoVariantParams;

--- a/identity/src/api.rs
+++ b/identity/src/api.rs
@@ -36,7 +36,7 @@ pub fn open(cpk: &CompactPublicKey, signed_message: &[u8], params_enum: &MayoPar
     let params = params_enum.variant();
     
     // Determine signature length: s_bytes_len (n elements) + salt_bytes
-    let s_bytes_len = params_enum.bytes_for_gf16_elements(params.n);
+    let s_bytes_len = MayoParams::bytes_for_gf16_elements(params.n);
     let expected_sig_len = s_bytes_len + params.salt_bytes;
 
     if signed_message.len() < expected_sig_len {
@@ -67,7 +67,7 @@ pub fn open(cpk: &CompactPublicKey, signed_message: &[u8], params_enum: &MayoPar
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::params::MayoParams;
+    use crate::params::MayoParams; // This is MayoParams enum type itself
     // Message and Signature types are already imported if needed.
 
     #[test]
@@ -112,7 +112,7 @@ mod tests {
         
         // Create a dummy "signed message"
         // Signature part: s_bytes (n elements) + salt_bytes
-        let s_bytes_len = params_enum.bytes_for_gf16_elements(params_enum.n());
+        let s_bytes_len = MayoParams::bytes_for_gf16_elements(params_enum.variant().n); // Corrected call
         let expected_sig_len = s_bytes_len + params_enum.salt_bytes();
         
         let dummy_sig_bytes = vec![0u8; expected_sig_len];
@@ -137,7 +137,7 @@ mod tests {
         let params_enum = MayoParams::mayo1();
         let (_csk, cpk) = keypair(&params_enum).expect("keypair generation failed");
         
-        let s_bytes_len = params_enum.bytes_for_gf16_elements(params_enum.n());
+        let s_bytes_len = MayoParams::bytes_for_gf16_elements(params_enum.variant().n); // Corrected call
         let expected_sig_len = s_bytes_len + params_enum.salt_bytes();
         
         let short_signed_message = vec![0u8; expected_sig_len - 1];

--- a/identity/src/sign.rs
+++ b/identity/src/sign.rs
@@ -144,11 +144,11 @@ pub fn sign_message(esk: &ExpandedSecretKey, message: &Message, params_enum: &Ma
     let p2_all_bytes_from_seedpk = derive_p2_bytes(&seedpk, params);
     let p3_all_bytes_from_seedpk = shake256_xof_derive_p3(&seedpk, params_enum);
 
-    let p2_matrices = decode_p2_matrices(&p2_all_bytes_from_seedpk, params)?;
-    let p3_matrices = decode_p3_matrices(&p3_all_bytes_from_seedpk, params)?;
+    let _p2_matrices = decode_p2_matrices(&p2_all_bytes_from_seedpk, params)?; // Prefixed
+    let _p3_matrices = decode_p3_matrices(&p3_all_bytes_from_seedpk, params)?; // Prefixed
     
     // O and L matrices are from esk.
-    let o_matrix = decode_o_matrix(o_bytes_slice, params)?;
+    let _o_matrix = decode_o_matrix(o_bytes_slice, params)?; // Prefixed
     let l_matrices = decode_l_matrices(l_all_bytes_slice, params)?;
 
 


### PR DESCRIPTION
This commit addresses several Rust compilation errors and warnings that reappeared or were identified after initial fixes:

- Verifies that `Copy` trait is not derived for `Vec<u8>`-containing structs in `types.rs`, resolving potential E0277 errors.
- Corrects the call to `MayoParams::bytes_for_gf16_elements` in `api.rs` to use associated function syntax, fixing an E0599 error.
- Removes an unused `KeyInit` import from `aes_ctr.rs`.
- Prefixes unused variables in `sign.rs` with underscores to silence compiler warnings.

After these changes, `cargo build --release` only fails due to known `wasm-bindgen` ABI compatibility errors in `src/api.rs`. All other Rust-level compilation errors and warnings have been resolved.